### PR TITLE
Update UnrealYAML.uplugin - no content required

### DIFF
--- a/UnrealYAML.uplugin
+++ b/UnrealYAML.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"CanContainContent": true,
+	"CanContainContent": false,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,
 	"Installed": false,


### PR DESCRIPTION
Better practice to disable CanContainContent if there is no content in the plugin.